### PR TITLE
feat: add library browser and request download status tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,37 @@ SABNZBD_BASE_URL=http://jpcoder.duckdns.org:38080
 SABNZBD_API_KEY=
 ```
 
+## Deployment
+
+### Environment
+
+| Component | URL / Resource |
+|-----------|---------------|
+| **Frontend** | https://plex.jpdxsolo.com/ |
+| **Backend API** | https://w6fn8e41qf.execute-api.us-east-1.amazonaws.com |
+| **S3 Bucket** | `plex-request-api-devtest-frontend` |
+| **CloudFront ID** | `EIYHZFZ7PKY0J` (`d12olgsb7r1u46.cloudfront.net`) |
+| **Serverless Stage** | `devtest` |
+| **AWS Profile** | `league-szn` |
+| **Cognito User Pool** | `us-east-1_5QNT47Ud7` |
+| **Cognito Client ID** | `6plp7icdstc1vtk7dahkrbnmpe` |
+
+### Deploy Commands
+
+```bash
+# Backend
+cd backend && npx serverless deploy --stage devtest --aws-profile league-szn
+
+# Frontend
+cd frontend && npm run build -- --mode devtest && aws s3 sync dist s3://plex-request-api-devtest-frontend --profile league-szn --delete
+
+# CloudFront cache invalidation
+aws cloudfront create-invalidation --distribution-id EIYHZFZ7PKY0J --paths "/*" --profile league-szn
+
+# Full deployment (backend + frontend + invalidation)
+cd backend && npx serverless deploy --stage devtest --aws-profile league-szn && cd ../frontend && npm run build -- --mode devtest && aws s3 sync dist s3://plex-request-api-devtest-frontend --profile league-szn --delete && aws cloudfront create-invalidation --distribution-id EIYHZFZ7PKY0J --paths "/*" --profile league-szn
+```
+
 ## Local Development
 ```bash
 # Backend: start DynamoDB Local + serverless-offline

--- a/backend/functions/admin/requests/updateStatus.ts
+++ b/backend/functions/admin/requests/updateStatus.ts
@@ -48,15 +48,20 @@ async function handleApproval(request: MediaRequest): Promise<{ radarrId?: numbe
 
     const config = { baseUrl: setting.baseUrl, apiKey: setting.apiKey };
 
-    // Sonarr lookup accepts tmdb:<id> format
+    // Sonarr lookup accepts tmdb:<id> format — find the correct match
     const results = await sonarr.lookupSeries(config, `tmdb:${request.tmdbId}`);
     if (!results.length) {
       throw new Error(`Series not found in Sonarr for TMDB ID ${request.tmdbId}`);
     }
 
+    // Match by tmdbId first, fall back to title match, then first result
+    const match = results.find((r) => r.tmdbId === request.tmdbId)
+      ?? results.find((r) => r.title.toLowerCase() === request.title.toLowerCase())
+      ?? results[0];
+
     const series = await sonarr.addSeries(
       config,
-      results[0].tvdbId,
+      match.tvdbId,
       setting.qualityProfileId,
       setting.rootFolderPath,
       request.seasons,

--- a/backend/lib/integrations/sonarr.ts
+++ b/backend/lib/integrations/sonarr.ts
@@ -23,6 +23,7 @@ interface SonarrSeriesStatistics {
 interface SonarrSeries {
   id: number;
   tvdbId: number;
+  tmdbId?: number;
   title: string;
   year: number;
   overview: string;

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -11,7 +11,7 @@ const statusConfig: Record<RequestStatus, { label: string; className: string }> 
 };
 
 export function StatusBadge({ status }: { status: RequestStatus }) {
-  const config = statusConfig[status];
+  const config = statusConfig[status] ?? { label: status, className: 'bg-muted text-muted-foreground' };
   return (
     <Badge variant="outline" className={cn('text-xs', config.className)}>
       {config.label}


### PR DESCRIPTION
## Summary
- **Library Browser**: New page to browse movies and TV shows already in the Plex library via Radarr/Sonarr, with search, pagination, and episode detail views
- **Download Status Tracking**: Requests now show real-time download progress from Radarr/Sonarr queue, with progress bars and status badges
- **Sonarr Matching Fix**: Improved series lookup to match by tmdbId before falling back to title or first result
- **StatusBadge Resilience**: Gracefully handles unknown request statuses instead of crashing
- **Admin Settings**: Added quality profile and root folder selection for Radarr/Sonarr configuration

## Test plan
- [ ] Verify Library page loads and displays movies/shows from Radarr and Sonarr
- [ ] Test library search and pagination
- [ ] Click a TV show to verify episode detail page renders seasons/episodes
- [ ] Submit a new request and verify download status polling shows progress
- [ ] Approve a TV show request and confirm Sonarr series matching uses tmdbId
- [ ] Verify unknown status values render gracefully in StatusBadge

🤖 Generated with [Claude Code](https://claude.com/claude-code)