### PR TITLE
feat: auto-approve requests from trusted users

### DIFF
--- a/backend/functions/admin/requests/updateStatus.ts
+++ b/backend/functions/admin/requests/updateStatus.ts
@@ -2,9 +2,7 @@ import type { APIGatewayProxyEventV2WithJWTAuthorizer, APIGatewayProxyResultV2 }
 import { getItem, updateItem, REQUESTS_TABLE } from '../../../lib/dynamodb';
 import { requireAdmin } from '../../../lib/auth';
 import { success, badRequest, notFound, forbidden, serverError } from '../../../lib/response';
-import { getServiceSetting } from '../../../lib/settings';
-import * as radarr from '../../../lib/integrations/radarr';
-import * as sonarr from '../../../lib/integrations/sonarr';
+import { handleApproval } from '../../../lib/approval';
 import type { MediaRequest, RequestStatus } from '../../../types';
 import { VALID_STATUS_TRANSITIONS as transitions } from '../../../types';
 import { sendStatusChangeEmail } from '../../../lib/email';
@@ -12,66 +10,6 @@ import { sendStatusChangeEmail } from '../../../lib/email';
 interface UpdateStatusBody {
   status: RequestStatus;
   adminNote?: string;
-}
-
-async function handleApproval(request: MediaRequest): Promise<{ radarrId?: number; sonarrId?: number }> {
-  if (request.mediaType === 'movie') {
-    const setting = await getServiceSetting('radarr');
-
-    if (!setting.enabled || !setting.baseUrl || !setting.apiKey) {
-      throw new Error('Radarr is not configured or disabled');
-    }
-    if (!setting.qualityProfileId || !setting.rootFolderPath) {
-      throw new Error('Radarr quality profile and root folder must be configured in Settings');
-    }
-
-    const config = { baseUrl: setting.baseUrl, apiKey: setting.apiKey };
-    const movie = await radarr.addMovie(
-      config,
-      request.tmdbId,
-      setting.qualityProfileId,
-      setting.rootFolderPath
-    );
-
-    return { radarrId: movie.id };
-  }
-
-  if (request.mediaType === 'tv') {
-    const setting = await getServiceSetting('sonarr');
-
-    if (!setting.enabled || !setting.baseUrl || !setting.apiKey) {
-      throw new Error('Sonarr is not configured or disabled');
-    }
-    if (!setting.qualityProfileId || !setting.rootFolderPath) {
-      throw new Error('Sonarr quality profile and root folder must be configured in Settings');
-    }
-
-    const config = { baseUrl: setting.baseUrl, apiKey: setting.apiKey };
-
-    // Sonarr lookup accepts tmdb:<id> format — find the correct match
-    const results = await sonarr.lookupSeries(config, `tmdb:${request.tmdbId}`);
-    if (!results.length) {
-      throw new Error(`Series not found in Sonarr for TMDB ID ${request.tmdbId}`);
-    }
-
-    // Match by tmdbId first, fall back to title match, then first result
-    const match = results.find((r) => r.tmdbId === request.tmdbId)
-      ?? results.find((r) => r.title.toLowerCase() === request.title.toLowerCase())
-      ?? results[0];
-
-    const series = await sonarr.addSeries(
-      config,
-      match.tvdbId,
-      setting.qualityProfileId,
-      setting.rootFolderPath,
-      request.seasons,
-      setting.languageProfileId
-    );
-
-    return { sonarrId: series.id };
-  }
-
-  return {};
 }
 
 export const handler = async (

--- a/backend/functions/admin/users/list.ts
+++ b/backend/functions/admin/users/list.ts
@@ -1,0 +1,85 @@
+import type { APIGatewayProxyEventV2WithJWTAuthorizer, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { requireAdmin } from '../../../lib/auth';
+import { scan, queryCount, USER_PREFERENCES_TABLE, REQUESTS_TABLE } from '../../../lib/dynamodb';
+import { success, forbidden, serverError } from '../../../lib/response';
+import type { AdminUser, UserPreference } from '../../../types';
+
+const cognito = new CognitoIdentityProviderClient({});
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+
+export const handler = async (
+  event: APIGatewayProxyEventV2WithJWTAuthorizer
+): Promise<APIGatewayProxyResultV2> => {
+  const admin = requireAdmin(event);
+  if (!admin) {
+    return forbidden('Admin access required');
+  }
+
+  try {
+    // Fetch all Cognito users (paginate if needed)
+    const cognitoUsers: Array<{
+      userId: string;
+      email: string;
+      status: string;
+      createdAt: string;
+    }> = [];
+
+    let paginationToken: string | undefined;
+    do {
+      const command = new ListUsersCommand({
+        UserPoolId: USER_POOL_ID,
+        Limit: 60,
+        PaginationToken: paginationToken,
+      });
+      const result = await cognito.send(command);
+
+      for (const user of result.Users ?? []) {
+        const sub = user.Attributes?.find((a) => a.Name === 'sub')?.Value ?? '';
+        const email = user.Attributes?.find((a) => a.Name === 'email')?.Value ?? '';
+        cognitoUsers.push({
+          userId: sub,
+          email,
+          status: user.UserStatus ?? 'UNKNOWN',
+          createdAt: user.UserCreateDate?.toISOString() ?? '',
+        });
+      }
+
+      paginationToken = result.PaginationToken;
+    } while (paginationToken);
+
+    // Fetch all user preferences
+    const prefs = await scan({ TableName: USER_PREFERENCES_TABLE }) as UserPreference[];
+    const prefMap = new Map(prefs.map((p) => [p.userId, p]));
+
+    // Fetch request counts per user in parallel
+    const countPromises = cognitoUsers.map(async (u) => {
+      const count = await queryCount({
+        TableName: REQUESTS_TABLE,
+        IndexName: 'UserIndex',
+        KeyConditionExpression: 'userId = :userId',
+        ExpressionAttributeValues: { ':userId': u.userId },
+      });
+      return { userId: u.userId, count };
+    });
+    const counts = await Promise.all(countPromises);
+    const countMap = new Map(counts.map((c) => [c.userId, c.count]));
+
+    const users: AdminUser[] = cognitoUsers.map((u) => ({
+      userId: u.userId,
+      email: u.email,
+      status: u.status,
+      autoApprove: prefMap.get(u.userId)?.autoApprove ?? false,
+      requestCount: countMap.get(u.userId) ?? 0,
+      createdAt: u.createdAt,
+    }));
+
+    return success({ users });
+  } catch (error) {
+    console.error('List users error:', error);
+    return serverError('Failed to list users');
+  }
+};

--- a/backend/functions/admin/users/updateAutoApprove.ts
+++ b/backend/functions/admin/users/updateAutoApprove.ts
@@ -1,0 +1,64 @@
+import type { APIGatewayProxyEventV2WithJWTAuthorizer, APIGatewayProxyResultV2 } from 'aws-lambda';
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { requireAdmin } from '../../../lib/auth';
+import { putItem, USER_PREFERENCES_TABLE } from '../../../lib/dynamodb';
+import { success, badRequest, notFound, forbidden, serverError } from '../../../lib/response';
+import type { UserPreference } from '../../../types';
+
+const cognito = new CognitoIdentityProviderClient({});
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+
+export const handler = async (
+  event: APIGatewayProxyEventV2WithJWTAuthorizer
+): Promise<APIGatewayProxyResultV2> => {
+  const admin = requireAdmin(event);
+  if (!admin) {
+    return forbidden('Admin access required');
+  }
+
+  const userId = event.pathParameters?.userId;
+  if (!userId) {
+    return badRequest('userId is required');
+  }
+
+  if (!event.body) {
+    return badRequest('Request body is required');
+  }
+
+  const body = JSON.parse(event.body) as { autoApprove: boolean };
+  if (typeof body.autoApprove !== 'boolean') {
+    return badRequest('autoApprove must be a boolean');
+  }
+
+  try {
+    // Verify user exists in Cognito (AdminGetUser requires username, so use sub filter)
+    const listCmd = new ListUsersCommand({
+      UserPoolId: USER_POOL_ID,
+      Filter: `sub = "${userId}"`,
+      Limit: 1,
+    });
+    const result = await cognito.send(listCmd);
+    if (!result.Users?.length) {
+      return notFound('User not found');
+    }
+
+    const pref: UserPreference = {
+      userId,
+      autoApprove: body.autoApprove,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await putItem({
+      TableName: USER_PREFERENCES_TABLE,
+      Item: pref,
+    });
+
+    return success(pref);
+  } catch (error) {
+    console.error('Update auto-approve error:', error);
+    return serverError('Failed to update auto-approve setting');
+  }
+};

--- a/backend/functions/requests/create.ts
+++ b/backend/functions/requests/create.ts
@@ -1,9 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { APIGatewayProxyEventV2WithJWTAuthorizer, APIGatewayProxyResultV2 } from 'aws-lambda';
-import { putItem, query, REQUESTS_TABLE } from '../../lib/dynamodb';
+import { putItem, query, getItem, REQUESTS_TABLE, USER_PREFERENCES_TABLE } from '../../lib/dynamodb';
 import { getUserContext } from '../../lib/auth';
+import { handleApproval } from '../../lib/approval';
 import { created, badRequest, conflict, serverError } from '../../lib/response';
-import type { MediaType, MediaRequest } from '../../types';
+import type { MediaType, MediaRequest, UserPreference } from '../../types';
 
 interface CreateRequestBody {
   mediaType: MediaType;
@@ -78,8 +79,14 @@ export const handler = async (
       }
     }
 
+    // Check if user has auto-approve enabled
+    const userPref = await getItem({
+      TableName: USER_PREFERENCES_TABLE,
+      Key: { userId: user.userId },
+    }) as UserPreference | undefined;
+
     const now = new Date().toISOString();
-    const request: MediaRequest = {
+    const requestData: MediaRequest = {
       requestId: uuidv4(),
       userId: user.userId,
       userName: user.email,
@@ -95,12 +102,28 @@ export const handler = async (
       updatedAt: now,
     };
 
+    if (userPref?.autoApprove) {
+      try {
+        const integrationIds = await handleApproval(requestData);
+        requestData.status = 'approved';
+        requestData.autoApproved = true;
+        if (integrationIds.radarrId) requestData.radarrId = integrationIds.radarrId;
+        if (integrationIds.sonarrId) requestData.sonarrId = integrationIds.sonarrId;
+      } catch (error) {
+        // If auto-approve integration fails, fall back to manual approval
+        console.error('Auto-approve integration failed, falling back to manual:', error);
+        requestData.status = 'requested';
+        requestData.adminNote = 'Auto-approve failed: ' +
+          (error instanceof Error ? error.message : 'Unknown error');
+      }
+    }
+
     await putItem({
       TableName: REQUESTS_TABLE,
-      Item: request,
+      Item: requestData,
     });
 
-    return created(request);
+    return created(requestData);
   } catch (error) {
     console.error('Create request error:', error);
     return serverError('Failed to create request');

--- a/backend/lib/approval.ts
+++ b/backend/lib/approval.ts
@@ -1,0 +1,64 @@
+import { getServiceSetting } from './settings';
+import * as radarr from './integrations/radarr';
+import * as sonarr from './integrations/sonarr';
+import type { MediaRequest } from '../types';
+
+export async function handleApproval(request: MediaRequest): Promise<{ radarrId?: number; sonarrId?: number }> {
+  if (request.mediaType === 'movie') {
+    const setting = await getServiceSetting('radarr');
+
+    if (!setting.enabled || !setting.baseUrl || !setting.apiKey) {
+      throw new Error('Radarr is not configured or disabled');
+    }
+    if (!setting.qualityProfileId || !setting.rootFolderPath) {
+      throw new Error('Radarr quality profile and root folder must be configured in Settings');
+    }
+
+    const config = { baseUrl: setting.baseUrl, apiKey: setting.apiKey };
+    const movie = await radarr.addMovie(
+      config,
+      request.tmdbId,
+      setting.qualityProfileId,
+      setting.rootFolderPath
+    );
+
+    return { radarrId: movie.id };
+  }
+
+  if (request.mediaType === 'tv') {
+    const setting = await getServiceSetting('sonarr');
+
+    if (!setting.enabled || !setting.baseUrl || !setting.apiKey) {
+      throw new Error('Sonarr is not configured or disabled');
+    }
+    if (!setting.qualityProfileId || !setting.rootFolderPath) {
+      throw new Error('Sonarr quality profile and root folder must be configured in Settings');
+    }
+
+    const config = { baseUrl: setting.baseUrl, apiKey: setting.apiKey };
+
+    // Sonarr lookup accepts tmdb:<id> format — find the correct match
+    const results = await sonarr.lookupSeries(config, `tmdb:${request.tmdbId}`);
+    if (!results.length) {
+      throw new Error(`Series not found in Sonarr for TMDB ID ${request.tmdbId}`);
+    }
+
+    // Match by tmdbId first, fall back to title match, then first result
+    const match = results.find((r) => r.tmdbId === request.tmdbId)
+      ?? results.find((r) => r.title.toLowerCase() === request.title.toLowerCase())
+      ?? results[0];
+
+    const series = await sonarr.addSeries(
+      config,
+      match.tvdbId,
+      setting.qualityProfileId,
+      setting.rootFolderPath,
+      request.seasons,
+      setting.languageProfileId
+    );
+
+    return { sonarrId: series.id };
+  }
+
+  return {};
+}

--- a/backend/lib/dynamodb.ts
+++ b/backend/lib/dynamodb.ts
@@ -79,3 +79,4 @@ export const REQUESTS_TABLE = process.env.REQUESTS_TABLE ?? 'plex-request-api-de
 export const SETTINGS_TABLE = process.env.SETTINGS_TABLE ?? 'plex-request-api-devtest-settings';
 export const ISSUES_TABLE = process.env.ISSUES_TABLE ?? 'plex-request-api-devtest-issues';
 export const LIBRARY_TABLE = process.env.LIBRARY_TABLE ?? 'plex-request-api-devtest-library';
+export const USER_PREFERENCES_TABLE = process.env.USER_PREFERENCES_TABLE ?? 'plex-request-api-devtest-user-preferences';

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -17,6 +17,7 @@ provider:
     SETTINGS_TABLE: ${self:service}-${self:provider.stage}-settings
     ISSUES_TABLE: ${self:service}-${self:provider.stage}-issues
     LIBRARY_TABLE: ${self:service}-${self:provider.stage}-library
+    USER_PREFERENCES_TABLE: ${self:service}-${self:provider.stage}-user-preferences
     COGNITO_USER_POOL_ID: !Ref CognitoUserPool
     COGNITO_CLIENT_ID: !Ref CognitoUserPoolClient
     RADARR_BASE_URL: ${env:RADARR_BASE_URL, 'http://jpcoder.duckdns.org:7878'}
@@ -45,6 +46,7 @@ provider:
             - !GetAtt IssuesTable.Arn
             - !Join ['/', [!GetAtt IssuesTable.Arn, 'index/*']]
             - !GetAtt LibraryTable.Arn
+            - !GetAtt UserPreferencesTable.Arn
         - Effect: Allow
           Action:
             - cognito-idp:AdminGetUser
@@ -408,6 +410,25 @@ functions:
           authorizer:
             name: jwtAuthorizer
 
+  # Admin users
+  adminListUsers:
+    handler: functions/admin/users/list.handler
+    events:
+      - httpApi:
+          path: /admin/users
+          method: GET
+          authorizer:
+            name: jwtAuthorizer
+
+  adminUpdateAutoApprove:
+    handler: functions/admin/users/updateAutoApprove.handler
+    events:
+      - httpApi:
+          path: /admin/users/{userId}/auto-approve
+          method: PUT
+          authorizer:
+            name: jwtAuthorizer
+
 resources:
   Resources:
     # DynamoDB Tables
@@ -507,6 +528,18 @@ resources:
         TimeToLiveSpecification:
           AttributeName: ttl
           Enabled: true
+
+    UserPreferencesTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.USER_PREFERENCES_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
 
     # Cognito User Pool
     CognitoUserPool:

--- a/backend/types/index.ts
+++ b/backend/types/index.ts
@@ -18,10 +18,28 @@ export interface MediaRequest {
   status: RequestStatus;
   adminNote?: string;
   seasons?: number[];
+  autoApproved?: boolean;
   radarrId?: number;
   sonarrId?: number;
   requestedAt: string;
   updatedAt: string;
+}
+
+/** User preferences stored in UserPreferences table */
+export interface UserPreference {
+  userId: string;
+  autoApprove: boolean;
+  updatedAt: string;
+}
+
+/** Admin view of a user (merged from Cognito + UserPreferences + request stats) */
+export interface AdminUser {
+  userId: string;
+  email: string;
+  status: string;
+  autoApprove: boolean;
+  requestCount: number;
+  createdAt: string;
 }
 
 /** DynamoDB Settings table item */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { RequestsPage } from '@/pages/RequestsPage';
 import { DashboardPage } from '@/pages/admin/DashboardPage';
 import { RequestQueuePage } from '@/pages/admin/RequestQueuePage';
 import { IssueQueuePage } from '@/pages/admin/IssueQueuePage';
+import { UsersPage } from '@/pages/admin/UsersPage';
 import { SettingsPage } from '@/pages/admin/SettingsPage';
 import { ReportIssuePage } from '@/pages/ReportIssuePage';
 import { LibraryPage } from '@/pages/LibraryPage';
@@ -87,6 +88,7 @@ function App() {
             <Route path="/admin" element={<DashboardPage />} />
             <Route path="/admin/requests" element={<RequestQueuePage />} />
             <Route path="/admin/issues" element={<IssueQueuePage />} />
+            <Route path="/admin/users" element={<UsersPage />} />
             <Route path="/admin/settings" element={<SettingsPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/RequestCard.tsx
+++ b/frontend/src/components/RequestCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Film, Tv } from 'lucide-react';
+import { Film, Tv, Zap } from 'lucide-react';
 import { StatusBadge } from '@/components/StatusBadge';
 import type { MediaRequest, DownloadStatus } from '@/types';
 
@@ -80,6 +80,11 @@ export function RequestCard({ request, downloadStatus, actions }: RequestCardPro
           ) : (
             <div className="flex items-center gap-2">
               <StatusBadge status={request.status} />
+              {request.autoApproved && (
+                <span className="flex items-center gap-0.5 text-xs text-yellow-400" title="Auto-approved">
+                  <Zap className="h-3 w-3" />
+                </span>
+              )}
               <span className="text-xs text-muted-foreground">{date}</span>
             </div>
           )}

--- a/frontend/src/components/admin/AdminSidebar.tsx
+++ b/frontend/src/components/admin/AdminSidebar.tsx
@@ -1,11 +1,12 @@
 import { NavLink } from 'react-router-dom';
-import { LayoutDashboard, ListTodo, AlertTriangle, Settings } from 'lucide-react';
+import { LayoutDashboard, ListTodo, AlertTriangle, Users, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const links = [
   { to: '/admin', icon: LayoutDashboard, label: 'Dashboard', end: true },
   { to: '/admin/requests', icon: ListTodo, label: 'Request Queue' },
   { to: '/admin/issues', icon: AlertTriangle, label: 'Issues' },
+  { to: '/admin/users', icon: Users, label: 'Users' },
   { to: '/admin/settings', icon: Settings, label: 'Settings' },
 ];
 

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/frontend/src/pages/admin/RequestQueuePage.tsx
+++ b/frontend/src/pages/admin/RequestQueuePage.tsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   ChevronUp,
   Trash2,
+  Zap,
 } from 'lucide-react';
 
 const TABS: { value: string; label: string }[] = [
@@ -113,6 +114,11 @@ function RequestRow({
               <div className="flex items-center gap-2">
                 <h3 className="font-medium">{request.title}</h3>
                 <StatusBadge status={request.status} />
+                {request.autoApproved && (
+                  <span className="flex items-center gap-0.5 text-xs text-yellow-400" title="Auto-approved">
+                    <Zap className="h-3 w-3" />
+                  </span>
+                )}
               </div>
               <p className="text-sm text-muted-foreground">
                 {request.year} &middot; {request.mediaType === 'movie' ? 'Movie' : 'TV'}

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { admin } from '@/services/api';
+import { toast } from 'sonner';
+import { Users, Zap } from 'lucide-react';
+import type { AdminUser } from '@/types';
+
+export function UsersPage() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [confirmUser, setConfirmUser] = useState<AdminUser | null>(null);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  async function loadUsers() {
+    try {
+      const data = await admin.users.list();
+      setUsers(data);
+    } catch (err) {
+      toast.error('Failed to load users');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleToggleClick(user: AdminUser) {
+    setConfirmUser(user);
+  }
+
+  async function confirmToggle() {
+    if (!confirmUser) return;
+    setToggling(true);
+    try {
+      const newValue = !confirmUser.autoApprove;
+      await admin.users.updateAutoApprove(confirmUser.userId, newValue);
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.userId === confirmUser.userId ? { ...u, autoApprove: newValue } : u
+        )
+      );
+      toast.success(
+        newValue
+          ? `Auto-approve enabled for ${confirmUser.email}`
+          : `Auto-approve disabled for ${confirmUser.email}`
+      );
+    } catch (err) {
+      toast.error('Failed to update auto-approve setting');
+      console.error(err);
+    } finally {
+      setToggling(false);
+      setConfirmUser(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Users className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold">Users</h1>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : users.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <Users className="mb-3 h-10 w-10" />
+          <p>No registered users</p>
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-center">Requests</TableHead>
+                <TableHead className="text-center">Auto-Approve</TableHead>
+                <TableHead>Joined</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((user) => (
+                <TableRow key={user.userId}>
+                  <TableCell className="font-medium">{user.email}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className={
+                        user.status === 'CONFIRMED'
+                          ? 'bg-green-500/20 text-green-400 border-green-500/30'
+                          : 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+                      }
+                    >
+                      {user.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-center">{user.requestCount}</TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex items-center justify-center gap-2">
+                      <Switch
+                        checked={user.autoApprove}
+                        onCheckedChange={() => handleToggleClick(user)}
+                      />
+                      {user.autoApprove && (
+                        <Zap className="h-4 w-4 text-yellow-400" />
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {new Date(user.createdAt).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <Dialog open={!!confirmUser} onOpenChange={() => setConfirmUser(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmUser?.autoApprove ? 'Disable' : 'Enable'} Auto-Approve
+            </DialogTitle>
+            <DialogDescription>
+              {confirmUser?.autoApprove
+                ? `Disable auto-approve for ${confirmUser.email}? Their future requests will require manual admin approval.`
+                : `Enable auto-approve for ${confirmUser?.email}? Their future requests will skip the approval queue and be sent directly to Radarr/Sonarr.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmUser(null)} disabled={toggling}>
+              Cancel
+            </Button>
+            <Button onClick={confirmToggle} disabled={toggling}>
+              {toggling ? 'Updating...' : 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,8 @@ import type {
   RequestStatus,
   IssueStatus,
   User,
+  AdminUser,
+  UserPreference,
   LibraryItem,
   LibraryMovie,
   LibraryShow,
@@ -257,6 +259,19 @@ export const admin = {
 
     delete: (id: string) =>
       request<void>(`/admin/issues/${id}`, { method: 'DELETE' }),
+  },
+
+  users: {
+    list: async () => {
+      const data = await request<{ users: AdminUser[] }>('/admin/users');
+      return data.users;
+    },
+
+    updateAutoApprove: (userId: string, autoApprove: boolean) =>
+      request<UserPreference>(`/admin/users/${userId}/auto-approve`, {
+        method: 'PUT',
+        body: JSON.stringify({ autoApprove }),
+      }),
   },
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,10 +18,28 @@ export interface MediaRequest {
   status: RequestStatus;
   adminNote?: string;
   seasons?: number[];
+  autoApproved?: boolean;
   radarrId?: number;
   sonarrId?: number;
   requestedAt: string;
   updatedAt: string;
+}
+
+/** User preferences */
+export interface UserPreference {
+  userId: string;
+  autoApprove: boolean;
+  updatedAt: string;
+}
+
+/** Admin view of a user */
+export interface AdminUser {
+  userId: string;
+  email: string;
+  status: string;
+  autoApprove: boolean;
+  requestCount: number;
+  createdAt: string;
 }
 
 /** Media search result (normalized from Radarr/Sonarr) */


### PR DESCRIPTION
## Summary
- **UserPreferences DynamoDB table** stores per-user `autoApprove` flag
- **`GET /admin/users`** lists all Cognito users with auto-approve status and request counts
- **`PUT /admin/users/:userId/auto-approve`** toggles auto-approve with Cognito user verification
- **Modified `POST /requests`** checks auto-approve on creation — sends directly to Radarr/Sonarr, falls back to manual on failure
- **Shared `lib/approval.ts`** extracts approval logic from `updateStatus.ts` for reuse
- **Admin Users page** (`/admin/users`) with table, Switch toggles, and confirmation dialog
- **Auto-approve badge** (lightning bolt) on request cards and admin queue

Closes #55

## Test plan
- [ ] Deploy backend — verify UserPreferences table is created
- [ ] Visit `/admin/users` — confirm all Cognito users listed with correct email, status, request count
- [ ] Toggle auto-approve on for a user — confirm dialog appears and toggle persists on refresh
- [ ] As that user, create a new request — verify it's auto-approved and sent to Radarr/Sonarr
- [ ] Verify the request card shows the yellow lightning bolt badge
- [ ] Toggle auto-approve off — verify next request goes to `requested` status
- [ ] Test failure fallback: disable Radarr/Sonarr, create request as trusted user — should fall back to `requested` with admin note

🤖 Generated with [Claude Code](https://claude.com/claude-code)